### PR TITLE
readme: Make it clear that b=4 in TableTypePacked

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ In other implementation:
 - [panmari/cuckoofilter](https://github.com/panmari/cuckoofilter) use b=4, f=16 bit, which correspond to a false positive rate of `r ~= 0.0001`.
 - [irfansharif/cfilter](https://github.com/irfansharif/cfilter) can adjust b and f, but only can adjust f to 8x, which means it is in Bytes.
 
-In this implementation, you can adjust b and f to any value you want, and the Semi-sorting Buckets mentioned in paper is also available, which can save 1 bit per item.
+In this implementation, you can adjust b and f to any value you want in `TableTypeSingle` type implementation.
+
+In addition, the Semi-sorting Buckets mentioned in paper which can save 1 bit per item is also available in `TableTypePacked` type,
+note that b=4, only f is adjustable.
 
 ##### Why custom is important?
 


### PR DESCRIPTION
When creating a filter it's not clear that if the type is`TableTypePacked` the  provided `tagsPerBucket` is ignored and always b=4.
Therefore clarify it in the README.

Should consider making it more clear in the code (e.g. 2 different new filter functions per type with no option to adjust b for "packed" type)