### PR TITLE
Introduce DecodeFrom and EncodeReader

### DIFF
--- a/util.go
+++ b/util.go
@@ -5,6 +5,8 @@
 
 package cuckoo
 
+import "fmt"
+
 const (
 	bitsPerByte    = 8
 	bytesPerUint64 = 8
@@ -32,4 +34,15 @@ func maxLoadFactor(tagsPerBucket uint) float64 {
 	default:
 		return 0.99
 	}
+}
+
+func getBucketsFromHint(initialBucketsHint []byte, expectedLength uint) ([]byte, error) {
+	result := initialBucketsHint
+	if len(result) == 0 {
+		result = make([]byte, expectedLength)
+	}
+	if uint(len(result)) != expectedLength {
+		return nil, fmt.Errorf("buckets length should be %d but got %d", expectedLength, len(result))
+	}
+	return result, nil
 }


### PR DESCRIPTION
The buckets byte slice is the biggest part of the the memory used by the filter,
and might be several of GBs.

Common usage of a filter is in an environment with limited RAM size
based on the filter size, load it to memory on startup and dump it to
disk on teardown.
Currently the Encode and Decode methods duplicates the byte slice,
which makes the memory usage at the loading and dumping time to be (at
least) twice the filter size.

This commit introduces a new method for dumping the filter using a reader
of the internal byte slice, and a method for loading the filter based on
already fetched encoded bytes (from disk, network) and use them
internaly instead of making a copy.

+ formatting.